### PR TITLE
Utilizar BorderPane para facilitar ubicación de elementos

### DIFF
--- a/src/main/resources/Clima.fxml
+++ b/src/main/resources/Clima.fxml
@@ -8,58 +8,73 @@
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<VBox alignment="CENTER" style="-fx-background-color: #FFF;" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.ClimaController">
-   <children>
-      <ImageView fitHeight="150.0" fitWidth="600.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@BORDE%20SUPERIOR%20-%20BALANPY.png" />
-         </image>
-      </ImageView>
-      <ImageView fitHeight="150.0" fitWidth="100.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@logo-balanpy.png" />
-         </image>
-         <VBox.margin>
-            <Insets top="-50.0" />
-         </VBox.margin>
-      </ImageView>
-      <Label fx:id="avisoPaseo" alignment="CENTER" contentDisplay="CENTER" text="Aviso paseo" textAlignment="CENTER" wrapText="true">
-         <font>
-            <Font size="18.0" />
-         </font>
-         <VBox.margin>
-            <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
-         </VBox.margin>
-         <padding>
-            <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
-         </padding>
-      </Label>
-      <Label fx:id="temperaturaActual" alignment="CENTER" text="Temperatura externa actual" textOverrun="CENTER_ELLIPSIS">
-         <font>
-            <Font size="24.0" />
-         </font>
-      </Label>
-      <Separator prefHeight="20.0" prefWidth="500.0">
-         <VBox.margin>
-            <Insets />
-         </VBox.margin>
-         <padding>
-            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-         </padding></Separator>
-      <LineChart fx:id="tempChart">
-        <xAxis>
-          <CategoryAxis side="BOTTOM" />
-        </xAxis>
-        <yAxis>
-          <NumberAxis side="LEFT" />
-        </yAxis>
-         <VBox.margin>
-            <Insets bottom="20.0" left="30.0" right="30.0" />
-         </VBox.margin>
-      </LineChart>
+
+<BorderPane xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.ClimaController">
+   <center>
+      <VBox alignment="CENTER" style="-fx-background-color: #FFF;">
+         <children>
+            <Label fx:id="avisoPaseo" alignment="CENTER" contentDisplay="CENTER" text="Aviso paseo" textAlignment="CENTER" wrapText="true">
+               <font>
+                  <Font size="18.0" />
+               </font>
+               <VBox.margin>
+                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
+               </VBox.margin>
+               <padding>
+                  <Insets bottom="2.0" left="2.0" right="2.0" top="2.0" />
+               </padding>
+            </Label>
+            <Label fx:id="temperaturaActual" alignment="CENTER" text="Temperatura externa actual" textOverrun="CENTER_ELLIPSIS">
+               <font>
+                  <Font size="24.0" />
+               </font>
+            </Label>
+            <Separator prefHeight="20.0" prefWidth="500.0">
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+               <padding>
+                  <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+               </padding>
+            </Separator>
+            <LineChart fx:id="tempChart">
+              <xAxis>
+                <CategoryAxis side="BOTTOM" />
+              </xAxis>
+              <yAxis>
+                <NumberAxis side="LEFT" />
+              </yAxis>
+               <VBox.margin>
+                  <Insets bottom="20.0" left="30.0" right="30.0" />
+               </VBox.margin>
+            </LineChart>
+         </children>
+      </VBox>
+   </center>
+   <top>
+      <VBox alignment="TOP_CENTER" BorderPane.alignment="CENTER">
+         <children>
+            <ImageView fitHeight="150.0" fitWidth="600.0" pickOnBounds="true" preserveRatio="true">
+               <image>
+                  <Image url="@BORDE%20SUPERIOR%20-%20BALANPY.png" />
+               </image>
+            </ImageView>
+            <ImageView fitHeight="150.0" fitWidth="100.0" pickOnBounds="true" preserveRatio="true">
+               <image>
+                  <Image url="@logo-balanpy.png" />
+               </image>
+               <VBox.margin>
+                  <Insets top="-50.0" />
+               </VBox.margin>
+            </ImageView>
+         </children>
+      </VBox>
+   </top>
+   <bottom>
       <fx:include source="BarraTareas.fxml" />
-   </children>
-</VBox>
+   </bottom>
+</BorderPane>

--- a/src/main/resources/ConfiguracionMascota.fxml
+++ b/src/main/resources/ConfiguracionMascota.fxml
@@ -9,6 +9,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
@@ -16,124 +17,137 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<VBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="600.0" style="-fx-background-color: #FFF;" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.ConfiguracionMascota">
-   <children>
-      <Label text="Introducir Datos">
-         <VBox.margin>
-            <Insets bottom="25.0" top="10.0" />
-         </VBox.margin>
-         <font>
-            <Font name="System Bold" size="18.0" />
-         </font>
-      </Label>
-      <HBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="142.0" prefWidth="600.0">
-         <VBox.margin>
-            <Insets />
-         </VBox.margin>
+
+<BorderPane xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.ConfiguracionMascota">
+   <center>
+      <VBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="600.0" style="-fx-background-color: #FFF;">
          <children>
-            <VBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="115.0" prefWidth="200.0">
+            <Label text="Introducir Datos">
+               <VBox.margin>
+                  <Insets bottom="25.0" top="10.0" />
+               </VBox.margin>
+               <font>
+                  <Font name="System Bold" size="18.0" />
+               </font>
+            </Label>
+            <HBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="142.0" prefWidth="600.0">
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
                <children>
-                  <Button fx:id="esterilizacion" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Añadir Esterilización">
-                     <VBox.margin>
-                        <Insets bottom="8.0" />
-                     </VBox.margin></Button>
-                  <Button fx:id="dni_mascota" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Añadir DNI Mascota">
-                     <VBox.margin>
-                        <Insets bottom="8.0" />
-                     </VBox.margin></Button>
-                  <Button fx:id="pedigree" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Añadir Archivo Pedigree" />
+                  <VBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="115.0" prefWidth="200.0">
+                     <children>
+                        <Button fx:id="esterilizacion" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Añadir Esterilización">
+                           <VBox.margin>
+                              <Insets bottom="8.0" />
+                           </VBox.margin>
+                        </Button>
+                        <Button fx:id="dni_mascota" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Añadir DNI Mascota">
+                           <VBox.margin>
+                              <Insets bottom="8.0" />
+                           </VBox.margin>
+                        </Button>
+                        <Button fx:id="pedigree" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Añadir Archivo Pedigree" />
+                     </children>
+                     <HBox.margin>
+                        <Insets right="-100.0" top="15.0" />
+                     </HBox.margin>
+                     <padding>
+                        <Insets top="3.0" />
+                     </padding>
+                  </VBox>
+                  <VBox alignment="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="130.0" prefWidth="120.0" styleClass="usuario" stylesheets="@usuario.css">
+                     <children>
+                        <ImageView fx:id="subir_mascota" fitHeight="75.0" fitWidth="75.0" onMouseClicked="#HandleDone" pickOnBounds="true" preserveRatio="true">
+                           <image>
+                              <Image url="@añadir-usuario-balanpy.png" />
+                           </image>
+                        </ImageView>
+                        <Label alignment="CENTER" contentDisplay="CENTER" text="Subir Foto">
+                           <font>
+                              <Font name="Open Sans Semibold" size="12.0" />
+                           </font>
+                        </Label>
+                     </children>
+                     <HBox.margin>
+                        <Insets left="115.0" right="-115.0" top="5.0" />
+                     </HBox.margin>
+                  </VBox>
+                  <VBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="115.0" prefWidth="200.0">
+                     <HBox.margin>
+                        <Insets left="135.0" right="4.0" top="15.0" />
+                     </HBox.margin>
+                     <children>
+                        <Button fx:id="eliminar_mascota" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Eliminar Perfil">
+                           <VBox.margin>
+                              <Insets bottom="8.0" />
+                           </VBox.margin>
+                        </Button>
+                        <Button fx:id="atras" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Atrás">
+                           <VBox.margin>
+                              <Insets bottom="8.0" />
+                           </VBox.margin>
+                        </Button>
+                        <Button fx:id="guardar_mascota" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Guardar" />
+                     </children>
+                     <padding>
+                        <Insets top="4.0" />
+                     </padding>
+                  </VBox>
                </children>
-               <HBox.margin>
-                  <Insets right="-100.0" top="15.0" />
-               </HBox.margin>
-               <padding>
-                  <Insets top="3.0" />
-               </padding></VBox>
-            <VBox alignment="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="130.0" prefWidth="120.0" styleClass="usuario" stylesheets="@usuario.css">
+            </HBox>
+            <HBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="400.0" prefWidth="500.0">
                <children>
-                  <ImageView fx:id="subir_mascota" fitHeight="75.0" fitWidth="75.0" onMouseClicked="#HandleDone" pickOnBounds="true" preserveRatio="true">
-                     <image>
-                        <Image url="@añadir-usuario-balanpy.png" />
-                     </image>
-                  </ImageView>
-                  <Label alignment="CENTER" contentDisplay="CENTER" text="Subir Foto">
-                     <font>
-                        <Font name="Open Sans Semibold" size="12.0" />
-                     </font>
-                  </Label>
+                  <GridPane hgap="26.0" prefHeight="400.0" prefWidth="500.0" vgap="21.0">
+                    <columnConstraints>
+                      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                    </columnConstraints>
+                    <rowConstraints>
+                      <RowConstraints maxHeight="28.0" minHeight="10.0" prefHeight="28.0" vgrow="SOMETIMES" />
+                      <RowConstraints maxHeight="43.0" minHeight="10.0" prefHeight="34.0" vgrow="SOMETIMES" />
+                      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                    </rowConstraints>
+                     <children>
+                        <Label contentDisplay="CENTER" text="Nombre *" />
+                        <TextField fx:id="nombre_mascota" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.rowIndex="1" />
+                        <Label contentDisplay="CENTER" text="Color" GridPane.columnIndex="1" />
+                        <TextField fx:id="color" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                        <Label contentDisplay="CENTER" text="Sexo *" GridPane.columnIndex="2" />
+                        <ChoiceBox fx:id="sexo_mascota" prefWidth="150.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+                        <Label contentDisplay="CENTER" text="Fecha Nacimiento *" GridPane.rowIndex="2" />
+                        <DatePicker fx:id="nacimiento" onAction="#getDate" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.rowIndex="3" />
+                        <Label contentDisplay="CENTER" text="Raza" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                        <TextField fx:id="raza" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                        <Label text="Esterilizada" GridPane.columnIndex="2" GridPane.rowIndex="2" />
+                        <ChoiceBox fx:id="esterilizada" prefWidth="150.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="2" GridPane.rowIndex="3" />
+                        <Label text="Grupo Sanguíneo" GridPane.rowIndex="4" />
+                        <ChoiceBox fx:id="sanguineo" prefWidth="150.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.rowIndex="5" />
+                        <Label text="Vacunas" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                        <ListView fx:id="vacunas" prefHeight="200.0" prefWidth="200.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="1" GridPane.rowIndex="5" />
+                        <Label contentDisplay="CENTER" text="Nº Chip  Mascota" GridPane.columnIndex="2" GridPane.rowIndex="4" />
+                        <TextField fx:id="chip" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="2" GridPane.rowIndex="5" />
+                        <Label contentDisplay="CENTER" text="Alergias" GridPane.rowIndex="6" />
+                        <ListView fx:id="alergias" prefHeight="200.0" prefWidth="200.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.rowIndex="7" />
+                        <Label contentDisplay="CENTER" text="Enfermedades" GridPane.columnIndex="2" GridPane.rowIndex="6" />
+                        <ListView fx:id="enfermedades" prefHeight="200.0" prefWidth="200.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="2" GridPane.rowIndex="7" />
+                     </children>
+                     <HBox.margin>
+                        <Insets bottom="18.0" top="18.0" />
+                     </HBox.margin>
+                  </GridPane>
                </children>
-               <HBox.margin>
-                  <Insets left="115.0" right="-115.0" top="5.0" />
-               </HBox.margin>
-            </VBox>
-            <VBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="115.0" prefWidth="200.0">
-               <HBox.margin>
-                  <Insets left="135.0" right="4.0" top="15.0" />
-               </HBox.margin>
-               <children>
-                  <Button fx:id="eliminar_mascota" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Eliminar Perfil">
-                     <VBox.margin>
-                        <Insets bottom="8.0" />
-                     </VBox.margin></Button>
-                  <Button fx:id="atras" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Atrás">
-                     <VBox.margin>
-                        <Insets bottom="8.0" />
-                     </VBox.margin></Button>
-                  <Button fx:id="guardar_mascota" alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="30.0" prefWidth="181.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Guardar" />
-               </children>
-               <padding>
-                  <Insets top="4.0" />
-               </padding>
-            </VBox>
-         </children></HBox>
-      <HBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="400.0" prefWidth="500.0">
-         <children>
-            <GridPane hgap="26.0" prefHeight="400.0" prefWidth="500.0" vgap="21.0">
-              <columnConstraints>
-                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-              </columnConstraints>
-              <rowConstraints>
-                <RowConstraints maxHeight="28.0" minHeight="10.0" prefHeight="28.0" vgrow="SOMETIMES" />
-                <RowConstraints maxHeight="43.0" minHeight="10.0" prefHeight="34.0" vgrow="SOMETIMES" />
-                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-              </rowConstraints>
-               <children>
-                  <Label contentDisplay="CENTER" text="Nombre *" />
-                  <TextField fx:id="nombre_mascota" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.rowIndex="1" />
-                  <Label contentDisplay="CENTER" text="Color" GridPane.columnIndex="1" />
-                  <TextField fx:id="color" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                  <Label contentDisplay="CENTER" text="Sexo *" GridPane.columnIndex="2" />
-                  <ChoiceBox fx:id="sexo_mascota" prefWidth="150.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="2" GridPane.rowIndex="1" />
-                  <Label contentDisplay="CENTER" text="Fecha Nacimiento *" GridPane.rowIndex="2" />
-                  <DatePicker fx:id="nacimiento" onAction="#getDate" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.rowIndex="3" />
-                  <Label contentDisplay="CENTER" text="Raza" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-                  <TextField fx:id="raza" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="1" GridPane.rowIndex="3" />
-                  <Label text="Esterilizada" GridPane.columnIndex="2" GridPane.rowIndex="2" />
-                  <ChoiceBox fx:id="esterilizada" prefWidth="150.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="2" GridPane.rowIndex="3" />
-                  <Label text="Grupo Sanguíneo" GridPane.rowIndex="4" />
-                  <ChoiceBox fx:id="sanguineo" prefWidth="150.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.rowIndex="5" />
-                  <Label text="Vacunas" GridPane.columnIndex="1" GridPane.rowIndex="4" />
-                  <ListView fx:id="vacunas" prefHeight="200.0" prefWidth="200.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-                  <Label contentDisplay="CENTER" text="Nº Chip  Mascota" GridPane.columnIndex="2" GridPane.rowIndex="4" />
-                  <TextField fx:id="chip" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="2" GridPane.rowIndex="5" />
-                  <Label contentDisplay="CENTER" text="Alergias" GridPane.rowIndex="6" />
-                  <ListView fx:id="alergias" prefHeight="200.0" prefWidth="200.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.rowIndex="7" />
-                  <Label contentDisplay="CENTER" text="Enfermedades" GridPane.columnIndex="2" GridPane.rowIndex="6" />
-                  <ListView fx:id="enfermedades" prefHeight="200.0" prefWidth="200.0" styleClass="boton-inferior-centro" stylesheets="@usuario.css" GridPane.columnIndex="2" GridPane.rowIndex="7" />
-               </children>
-               <HBox.margin>
-                  <Insets bottom="18.0" top="18.0" />
-               </HBox.margin>
-            </GridPane>
+            </HBox>
          </children>
-      </HBox>
+      </VBox>
+   </center>
+   <bottom>
       <fx:include source="BarraTareas.fxml" />
-   </children>
-</VBox>
+   </bottom>
+</BorderPane>

--- a/src/main/resources/PantallaInicio.fxml
+++ b/src/main/resources/PantallaInicio.fxml
@@ -5,106 +5,119 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<VBox alignment="TOP_CENTER" prefHeight="800.0" prefWidth="600.0" style="-fx-background-color: #FFF;" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.Inicio">
-   <children>
-      <ImageView fitHeight="100.0" fitWidth="600.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@BORDE%20SUPERIOR%20-%20BALANPY.png" />
-         </image>
-      </ImageView>
-            <ImageView fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@logo-balanpy.png" />
-         </image>
-         <VBox.margin>
-            <Insets />
-         </VBox.margin></ImageView>
-            <Label contentDisplay="TOP" text="Bienvenido a Balanpy" textFill="#82d4c9">
-               <font>
-                  <Font name="Poppins Bold" size="32.0" />
-               </font>
-               <opaqueInsets>
-                  <Insets />
-               </opaqueInsets>
-               <VBox.margin>
-                  <Insets top="20.0" />
-               </VBox.margin>
-            </Label>
-            <Label contentDisplay="TOP" layoutX="110.0" layoutY="307.0" text="Regístrate ahora">
-               <font>
-                  <Font name="Poppins Bold" size="18.0" />
-               </font>
-               <opaqueInsets>
-                  <Insets />
-               </opaqueInsets>
-               <VBox.margin>
-                  <Insets bottom="10.0" />
-               </VBox.margin>
-         <padding>
-            <Insets bottom="30.0" />
-         </padding>
-            </Label>
-      <VBox alignment="TOP_CENTER" fillWidth="false" maxWidth="-Infinity" onMouseClicked="#crearUsuario" prefHeight="200.0" prefWidth="180.0" styleClass="usuario" stylesheets="@usuario.css">
+
+<BorderPane style="-fx-background-color: #FFF;" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.Inicio">
+   <center>
+      <VBox alignment="TOP_CENTER">
          <children>
-            <ImageView fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true">
+                  <Label contentDisplay="TOP" text="Bienvenido a Balanpy" textFill="#82d4c9">
+                     <font>
+                        <Font name="Poppins Bold" size="32.0" />
+                     </font>
+                     <opaqueInsets>
+                        <Insets />
+                     </opaqueInsets>
+                     <VBox.margin>
+                        <Insets top="20.0" />
+                     </VBox.margin>
+                  </Label>
+                  <Label contentDisplay="TOP" layoutX="110.0" layoutY="307.0" text="Regístrate ahora">
+                     <font>
+                        <Font name="Poppins Bold" size="18.0" />
+                     </font>
+                     <opaqueInsets>
+                        <Insets />
+                     </opaqueInsets>
+                     <VBox.margin>
+                        <Insets bottom="10.0" />
+                     </VBox.margin>
+               <padding>
+                  <Insets bottom="30.0" />
+               </padding>
+                  </Label>
+            <VBox alignment="TOP_CENTER" fillWidth="false" maxWidth="-Infinity" onMouseClicked="#crearUsuario" prefHeight="200.0" prefWidth="180.0" styleClass="usuario" stylesheets="@usuario.css">
+               <children>
+                  <ImageView fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true">
+                     <image>
+                        <Image url="@añadir-usuario-balanpy.png" />
+                     </image>
+                  </ImageView>
+                  <Label onMouseClicked="#crearUsuario" text="Añadir Usuario">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                  </Label>
+               </children>
+               <opaqueInsets>
+                  <Insets />
+               </opaqueInsets>
+            </VBox>
+            <GridPane alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="80.0" prefWidth="500.0">
+              <columnConstraints>
+                <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                  <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+              </rowConstraints>
+               <children>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="55.0" prefWidth="150.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Términos de Uso y Condiciones" textAlignment="CENTER" textFill="WHITE" wrapText="true">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                     <GridPane.margin>
+                        <Insets />
+                     </GridPane.margin>
+                  </Button>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="55.0" prefWidth="150.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Acerca de Nosotros" textAlignment="CENTER" textFill="WHITE" wrapText="true" GridPane.columnIndex="1">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                     <GridPane.margin>
+                        <Insets />
+                     </GridPane.margin>
+                  </Button>
+                  <Button layoutX="149.0" layoutY="35.0" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="55.0" prefWidth="150.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Manual de Uso" textAlignment="CENTER" textFill="WHITE" wrapText="true" GridPane.columnIndex="2">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                     <GridPane.margin>
+                        <Insets />
+                     </GridPane.margin>
+                  </Button>
+               </children>
+               <VBox.margin>
+                  <Insets top="50.0" />
+               </VBox.margin>
+            </GridPane>
+               </children>
+      </VBox>
+   </center>
+   <top>
+      <VBox alignment="CENTER" BorderPane.alignment="CENTER">
+         <children>
+            <ImageView fitHeight="100.0" fitWidth="600.0" pickOnBounds="true" preserveRatio="true">
                <image>
-                  <Image url="@añadir-usuario-balanpy.png" />
+                  <Image url="@BORDE%20SUPERIOR%20-%20BALANPY.png" />
                </image>
             </ImageView>
-            <Label onMouseClicked="#crearUsuario" text="Añadir Usuario">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-            </Label>
+                  <ImageView fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
+               <image>
+                  <Image url="@logo-balanpy.png" />
+               </image>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+            </ImageView>
          </children>
-         <opaqueInsets>
-            <Insets />
-         </opaqueInsets>
       </VBox>
-      <GridPane alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="80.0" prefWidth="500.0">
-        <columnConstraints>
-          <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-          <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-            <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="55.0" prefWidth="150.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Términos de Uso y Condiciones" textAlignment="CENTER" textFill="WHITE" wrapText="true">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-               <GridPane.margin>
-                  <Insets />
-               </GridPane.margin>
-            </Button>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="55.0" prefWidth="150.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Acerca de Nosotros" textAlignment="CENTER" textFill="WHITE" wrapText="true" GridPane.columnIndex="1">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-               <GridPane.margin>
-                  <Insets />
-               </GridPane.margin>
-            </Button>
-            <Button layoutX="149.0" layoutY="35.0" maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="55.0" prefWidth="150.0" styleClass="boton_personalizado" stylesheets="@usuario.css" text="Manual de Uso" textAlignment="CENTER" textFill="WHITE" wrapText="true" GridPane.columnIndex="2">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-               <GridPane.margin>
-                  <Insets />
-               </GridPane.margin>
-            </Button>
-         </children>
-         <VBox.margin>
-            <Insets top="50.0" />
-         </VBox.margin>
-      </GridPane>
-         </children>
-</VBox>
+   </top>
+</BorderPane>

--- a/src/main/resources/PerfilMascota.fxml
+++ b/src/main/resources/PerfilMascota.fxml
@@ -8,6 +8,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
@@ -16,199 +17,206 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.PerfilMascota">
-   <children>
-      <GridPane alignment="CENTER" prefHeight="161.0" prefWidth="600.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="295.0" minWidth="10.0" prefWidth="210.0" />
-            <ColumnConstraints hgrow="SOMETIMES" maxWidth="378.0" minWidth="10.0" prefWidth="115.0" />
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="378.0" minWidth="10.0" prefWidth="114.0" />
-            <ColumnConstraints hgrow="SOMETIMES" maxWidth="378.0" minWidth="10.0" prefWidth="161.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints maxHeight="167.0" minHeight="10.0" prefHeight="160.0" vgrow="SOMETIMES" />
-        </rowConstraints>
+
+<BorderPane xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.PerfilMascota">
+   <center>
+      <VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity">
          <children>
-            <VBox prefHeight="200.0" prefWidth="100.0" spacing="3.0" GridPane.columnIndex="2">
+            <GridPane alignment="CENTER" prefHeight="161.0" prefWidth="600.0">
+              <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="295.0" minWidth="10.0" prefWidth="210.0" />
+                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="378.0" minWidth="10.0" prefWidth="115.0" />
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="378.0" minWidth="10.0" prefWidth="114.0" />
+                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="378.0" minWidth="10.0" prefWidth="161.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints maxHeight="167.0" minHeight="10.0" prefHeight="160.0" vgrow="SOMETIMES" />
+              </rowConstraints>
                <children>
-                  <Text fx:id="edad" strokeType="OUTSIDE" strokeWidth="0.0" text="edad" />
-                  <Text fx:id="sexo" strokeType="OUTSIDE" strokeWidth="0.0" text="sexo" />
-                  <Text fx:id="color" strokeType="OUTSIDE" strokeWidth="0.0" text="color" />
-                  <Text fx:id="raza" strokeType="OUTSIDE" strokeWidth="0.0" text="raza" />
-                  <Text fx:id="fechaNacimiento" strokeType="OUTSIDE" strokeWidth="0.0" text="f_nacimiento" />
-                  <Text fx:id="esterilizado" strokeType="OUTSIDE" strokeWidth="0.0" text="esterilizado" />
-                  <Text fx:id="grupoSanguineo" strokeType="OUTSIDE" strokeWidth="0.0" text="g_sanguineo" />
+                  <VBox prefHeight="200.0" prefWidth="100.0" spacing="3.0" GridPane.columnIndex="2">
+                     <children>
+                        <Text fx:id="edad" strokeType="OUTSIDE" strokeWidth="0.0" text="edad" />
+                        <Text fx:id="sexo" strokeType="OUTSIDE" strokeWidth="0.0" text="sexo" />
+                        <Text fx:id="color" strokeType="OUTSIDE" strokeWidth="0.0" text="color" />
+                        <Text fx:id="raza" strokeType="OUTSIDE" strokeWidth="0.0" text="raza" />
+                        <Text fx:id="fechaNacimiento" strokeType="OUTSIDE" strokeWidth="0.0" text="f_nacimiento" />
+                        <Text fx:id="esterilizado" strokeType="OUTSIDE" strokeWidth="0.0" text="esterilizado" />
+                        <Text fx:id="grupoSanguineo" strokeType="OUTSIDE" strokeWidth="0.0" text="g_sanguineo" />
+                     </children>
+                     <opaqueInsets>
+                        <Insets />
+                     </opaqueInsets>
+                     <GridPane.margin>
+                        <Insets top="20.0" />
+                     </GridPane.margin>
+                  </VBox>
+                  <VBox alignment="TOP_CENTER" prefHeight="200.0" prefWidth="115.0" spacing="3.0" GridPane.columnIndex="1">
+                     <children>
+                        <Label text="Edad: " />
+                        <Label text="Sexo: " />
+                        <Label text="Color: " />
+                        <Label text="Raza: " />
+                        <Label text="Fecha Nacimiento: " />
+                        <Label text="Esterilizad@: " />
+                        <Label text="Grupo Sanguíneo: " />
+                     </children>
+                     <GridPane.margin>
+                        <Insets top="20.0" />
+                     </GridPane.margin>
+                  </VBox>
+                  <VBox alignment="TOP_CENTER" prefHeight="200.0" prefWidth="100.0" GridPane.columnIndex="3">
+                     <children>
+                        <ImageView fitHeight="100.0" fitWidth="100.0" pickOnBounds="true" preserveRatio="true">
+                           <image>
+                              <Image url="@logo-balanpy.png" />
+                           </image>
+                        </ImageView>
+                     </children>
+                     <padding>
+                        <Insets top="20.0" />
+                     </padding>
+                  </VBox>
+                  <GridPane>
+                    <columnConstraints>
+                      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                    </columnConstraints>
+                    <rowConstraints>
+                      <RowConstraints maxHeight="166.0" minHeight="10.0" prefHeight="165.0" vgrow="SOMETIMES" />
+                    </rowConstraints>
+                     <children>
+                        <ImageView fx:id="fotoMascota" fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true">
+                           <image>
+                              <Image url="@Portada-Bulldog.png" />
+                           </image>
+                           <GridPane.margin>
+                              <Insets left="30.0" />
+                           </GridPane.margin>
+                        </ImageView>
+                     </children>
+                  </GridPane>
+               </children>
+            </GridPane>
+            <GridPane prefHeight="67.0" prefWidth="600.0">
+              <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="295.0" minWidth="10.0" prefWidth="205.0" />
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="408.0" minWidth="10.0" prefWidth="395.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+              </rowConstraints>
+               <children>
+                  <Button fx:id="configuracionMascota" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="69.0" prefWidth="345.0" style="-fx-background-color: #87D5CA;" text="Configuración" textFill="WHITE" GridPane.columnIndex="1">
+                     <font>
+                        <Font size="14.0" />
+                     </font>
+                     <GridPane.margin>
+                        <Insets bottom="10.0" left="10.0" right="205.0" top="10.0" />
+                     </GridPane.margin>
+                  </Button>
+                  <Text fx:id="nombreMascota" strokeType="OUTSIDE" strokeWidth="0.0" text="nombre_mascota" textAlignment="CENTER">
+                     <GridPane.margin>
+                        <Insets bottom="40.0" left="65.0" />
+                     </GridPane.margin>
+                  </Text>
+               </children>
+            </GridPane>
+            <GridPane alignment="TOP_CENTER" prefHeight="259.0" prefWidth="600.0">
+              <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints maxHeight="239.0" minHeight="10.0" prefHeight="231.0" vgrow="SOMETIMES" />
+              </rowConstraints>
+               <children>
+                  <LineChart fx:id="temperaturaDiaria" title="Temperatura Diaria">
+                    <xAxis>
+                      <CategoryAxis side="BOTTOM" />
+                    </xAxis>
+                    <yAxis>
+                      <NumberAxis minorTickCount="10" tickLabelGap="5.0" upperBound="40.0" />
+                    </yAxis>
+                  </LineChart>
+                  <LineChart fx:id="pulsaciones" title="Pulsaciones" GridPane.columnIndex="1">
+                    <xAxis>
+                      <CategoryAxis side="BOTTOM" />
+                    </xAxis>
+                    <yAxis>
+                      <NumberAxis side="LEFT" upperBound="140.0" />
+                    </yAxis>
+                  </LineChart>
                </children>
                <opaqueInsets>
                   <Insets />
                </opaqueInsets>
-               <GridPane.margin>
+               <VBox.margin>
                   <Insets top="20.0" />
-               </GridPane.margin>
-            </VBox>
-            <VBox alignment="TOP_CENTER" prefHeight="200.0" prefWidth="115.0" spacing="3.0" GridPane.columnIndex="1">
-               <children>
-                  <Label text="Edad: " />
-                  <Label text="Sexo: " />
-                  <Label text="Color: " />
-                  <Label text="Raza: " />
-                  <Label text="Fecha Nacimiento: " />
-                  <Label text="Esterilizad@: " />
-                  <Label text="Grupo Sanguíneo: " />
-               </children>
-               <GridPane.margin>
-                  <Insets top="20.0" />
-               </GridPane.margin>
-            </VBox>
-            <VBox alignment="TOP_CENTER" prefHeight="200.0" prefWidth="100.0" GridPane.columnIndex="3">
-               <children>
-                  <ImageView fitHeight="100.0" fitWidth="100.0" pickOnBounds="true" preserveRatio="true">
-                     <image>
-                        <Image url="@logo-balanpy.png" />
-                     </image>
-                  </ImageView>
-               </children>
-               <padding>
-                  <Insets top="20.0" />
-               </padding>
-            </VBox>
-            <GridPane>
+               </VBox.margin>
+            </GridPane>
+            <GridPane prefHeight="93.0" prefWidth="600.0">
               <columnConstraints>
-                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="342.0" minWidth="10.0" prefWidth="327.0" />
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="295.0" minWidth="10.0" prefWidth="273.0" />
               </columnConstraints>
               <rowConstraints>
-                <RowConstraints maxHeight="166.0" minHeight="10.0" prefHeight="165.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
               </rowConstraints>
                <children>
-                  <ImageView fx:id="fotoMascota" fitHeight="150.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true">
-                     <image>
-                        <Image url="@Portada-Bulldog.png" />
-                     </image>
+                  <Button fx:id="saludMascota" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" prefWidth="300.0" style="-fx-background-color: #87D5CA;" text="Alergias, Vacunas y Enfermedades Anteriores" textFill="WHITE">
+                     <font>
+                        <Font size="14.0" />
+                     </font>
                      <GridPane.margin>
-                        <Insets left="30.0" />
+                        <Insets left="20.0" />
                      </GridPane.margin>
-                  </ImageView>
+                  </Button>
+                  <VBox alignment="CENTER" prefHeight="200.0" prefWidth="284.0" GridPane.columnIndex="1">
+                     <children>
+                        <Button fx:id="seguroMascota" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Seguro De La Mascota" textFill="WHITE">
+                           <font>
+                              <Font size="14.0" />
+                           </font>
+                        </Button>
+                     </children>
+                  </VBox>
                </children>
             </GridPane>
-         </children>
-      </GridPane>
-      <GridPane prefHeight="67.0" prefWidth="600.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="295.0" minWidth="10.0" prefWidth="205.0" />
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="408.0" minWidth="10.0" prefWidth="395.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-            <Button fx:id="configuracionMascota" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="69.0" prefWidth="345.0" style="-fx-background-color: #87D5CA;" text="Configuración" textFill="WHITE" GridPane.columnIndex="1">
-               <font>
-                  <Font size="14.0" />
-               </font>
-               <GridPane.margin>
-                  <Insets bottom="10.0" left="10.0" right="205.0" top="10.0" />
-               </GridPane.margin>
-            </Button>
-            <Text fx:id="nombreMascota" strokeType="OUTSIDE" strokeWidth="0.0" text="nombre_mascota" textAlignment="CENTER">
-               <GridPane.margin>
-                  <Insets bottom="40.0" left="65.0" />
-               </GridPane.margin>
-            </Text>
-         </children>
-      </GridPane>
-      <GridPane alignment="TOP_CENTER" prefHeight="259.0" prefWidth="600.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints maxHeight="239.0" minHeight="10.0" prefHeight="231.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-            <LineChart fx:id="temperaturaDiaria" title="Temperatura Diaria">
-              <xAxis>
-                <CategoryAxis side="BOTTOM" />
-              </xAxis>
-              <yAxis>
-                <NumberAxis minorTickCount="10" tickLabelGap="5.0" upperBound="40.0" />
-              </yAxis>
-            </LineChart>
-            <LineChart fx:id="pulsaciones" title="Pulsaciones" GridPane.columnIndex="1">
-              <xAxis>
-                <CategoryAxis side="BOTTOM" />
-              </xAxis>
-              <yAxis>
-                <NumberAxis side="LEFT" upperBound="140.0" />
-              </yAxis>
-            </LineChart>
-         </children>
-         <opaqueInsets>
-            <Insets />
-         </opaqueInsets>
-         <VBox.margin>
-            <Insets top="20.0" />
-         </VBox.margin>
-      </GridPane>
-      <GridPane prefHeight="93.0" prefWidth="600.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="342.0" minWidth="10.0" prefWidth="327.0" />
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="295.0" minWidth="10.0" prefWidth="273.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-            <Button fx:id="saludMascota" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" prefWidth="300.0" style="-fx-background-color: #87D5CA;" text="Alergias, Vacunas y Enfermedades Anteriores" textFill="WHITE">
-               <font>
-                  <Font size="14.0" />
-               </font>
-               <GridPane.margin>
-                  <Insets left="20.0" />
-               </GridPane.margin>
-            </Button>
-            <VBox alignment="CENTER" prefHeight="200.0" prefWidth="284.0" GridPane.columnIndex="1">
+            <HBox prefHeight="100.0" prefWidth="600.0" spacing="38.0">
                <children>
-                  <Button fx:id="seguroMascota" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Seguro De La Mascota" textFill="WHITE">
+                  <Button fx:id="dniMascota" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="DNI Mascota" textFill="WHITE">
+                     <font>
+                        <Font size="14.0" />
+                     </font>
+                  </Button>
+                  <Button fx:id="pedigree" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Pedigree" textFill="WHITE">
+                     <font>
+                        <Font size="14.0" />
+                     </font>
+                  </Button>
+                  <Button fx:id="chip" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Nº Chip" textFill="WHITE">
+                     <font>
+                        <Font size="14.0" />
+                     </font>
+                  </Button>
+                  <Button fx:id="esterilizado" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Esterilizado" textFill="WHITE">
+                     <font>
+                        <Font size="14.0" />
+                     </font>
+                  </Button>
+                  <Button fx:id="ppp" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Archivo P.P.P" textFill="WHITE">
                      <font>
                         <Font size="14.0" />
                      </font>
                   </Button>
                </children>
-            </VBox>
+               <padding>
+                  <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+               </padding>
+            </HBox>
          </children>
-      </GridPane>
-      <HBox prefHeight="100.0" prefWidth="600.0" spacing="38.0">
-         <children>
-            <Button fx:id="dniMascota" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="DNI Mascota" textFill="WHITE">
-               <font>
-                  <Font size="14.0" />
-               </font>
-            </Button>
-            <Button fx:id="pedigree" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Pedigree" textFill="WHITE">
-               <font>
-                  <Font size="14.0" />
-               </font>
-            </Button>
-            <Button fx:id="chip" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Nº Chip" textFill="WHITE">
-               <font>
-                  <Font size="14.0" />
-               </font>
-            </Button>
-            <Button fx:id="esterilizado" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Esterilizado" textFill="WHITE">
-               <font>
-                  <Font size="14.0" />
-               </font>
-            </Button>
-            <Button fx:id="ppp" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="50.0" style="-fx-background-color: #87D5CA;" text="Archivo P.P.P" textFill="WHITE">
-               <font>
-                  <Font size="14.0" />
-               </font>
-            </Button>
-         </children>
-         <padding>
-            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-         </padding>
-      </HBox>
+      </VBox>
+   </center>
+   <bottom>
       <fx:include source="BarraTareas.fxml" />
-   </children>
-</VBox>
+   </bottom>
+</BorderPane>

--- a/src/main/resources/PerfilUsuario.fxml
+++ b/src/main/resources/PerfilUsuario.fxml
@@ -5,6 +5,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
@@ -12,174 +13,183 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<VBox alignment="TOP_CENTER" prefHeight="800.0" prefWidth="600.0" style="-fx-background-color: #fff;" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.PerfilUsuario">
-   <children>
-      <ImageView pickOnBounds="true" preserveRatio="true">
+
+<BorderPane xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.PerfilUsuario">
+   <center>
+      <VBox alignment="TOP_CENTER" style="-fx-background-color: #fff;">
+         <children>
+            <GridPane maxHeight="-Infinity">
+              <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="307.0" minWidth="10.0" prefWidth="297.0" />
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="296.0" minWidth="10.0" prefWidth="161.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+              </rowConstraints>
+               <children>
+                  <Label text="Nombre:">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label text="Edad:" GridPane.rowIndex="1">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label text="Teléfono:" GridPane.rowIndex="2">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label text="Email:" GridPane.rowIndex="3">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label text="Sexo:" GridPane.rowIndex="4">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label text="Dirección" GridPane.rowIndex="5">
+                     <font>
+                        <Font name="Poppins Bold" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label fx:id="nombre" text="Jorge Fulanito" GridPane.columnIndex="1">
+                     <font>
+                        <Font name="Poppins" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label fx:id="edad" text="25 años" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                     <font>
+                        <Font name="Poppins" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label fx:id="telefono" text="+34 123 45 67 89" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                     <font>
+                        <Font name="Poppins" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label fx:id="email" text="jfulanito@hotmail.com" GridPane.columnIndex="1" GridPane.rowIndex="3">
+                     <font>
+                        <Font name="Poppins" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label fx:id="sexo" text="Masculino" GridPane.columnIndex="1" GridPane.rowIndex="4">
+                     <font>
+                        <Font name="Poppins" size="14.0" />
+                     </font>
+                  </Label>
+                  <Label fx:id="direccion" text="Calle Falsa 123, Madrid" GridPane.columnIndex="1" GridPane.rowIndex="5">
+                     <font>
+                        <Font name="Poppins" size="14.0" />
+                     </font>
+                  </Label>
+                  <ImageView fitHeight="148.0" fitWidth="151.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2" GridPane.rowIndex="2">
+                     <image>
+                        <Image url="@logo-balanpy.png" />
+                     </image>
+                  </ImageView>
+               </children>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+               <padding>
+                  <Insets left="20.0" right="20.0" />
+               </padding>
+            </GridPane>
+            <VBox alignment="CENTER_LEFT" maxWidth="1.7976931348623157E308">
+               <children>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Editar  Perfil" textAlignment="CENTER">
+                     <font>
+                        <Font name="Poppins Bold" size="12.0" />
+                     </font>
+                  </Button>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Cambio Contraseña (Próximamente)" textAlignment="CENTER" wrapText="true">
+                     <font>
+                        <Font name="Poppins Bold" size="12.0" />
+                     </font>
+                     <VBox.margin>
+                        <Insets top="10.0" />
+                     </VBox.margin>
+                  </Button>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Añadir Archivo PPP" textAlignment="CENTER" wrapText="true">
+                     <font>
+                        <Font name="Poppins Bold" size="12.0" />
+                     </font>
+                     <VBox.margin>
+                        <Insets top="10.0" />
+                     </VBox.margin>
+                  </Button>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Seguro" textAlignment="CENTER">
+                     <font>
+                        <Font name="Poppins Bold" size="12.0" />
+                     </font>
+                     <VBox.margin>
+                        <Insets top="10.0" />
+                     </VBox.margin>
+                  </Button>
+               </children>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+               <padding>
+                  <Insets left="20.0" right="20.0" top="20.0" />
+               </padding>
+            </VBox>
+            <HBox alignment="TOP_RIGHT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
+               <children>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Términos de Uso y Condiciones" textAlignment="CENTER" wrapText="true">
+                     <font>
+                        <Font name="Poppins Bold" size="12.0" />
+                     </font>
+                     <HBox.margin>
+                        <Insets right="10.0" />
+                     </HBox.margin>
+                  </Button>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Acerca de Nosotros" textAlignment="CENTER" wrapText="true">
+                     <font>
+                        <Font name="Poppins Bold" size="12.0" />
+                     </font>
+                     <HBox.margin>
+                        <Insets left="5.0" right="5.0" />
+                     </HBox.margin>
+                  </Button>
+                  <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Manual de Uso" textAlignment="CENTER" wrapText="true">
+                     <font>
+                        <Font name="Poppins Bold" size="12.0" />
+                     </font>
+                     <HBox.margin>
+                        <Insets left="10.0" />
+                     </HBox.margin>
+                  </Button>
+               </children>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+               <padding>
+                  <Insets bottom="30.0" left="20.0" right="20.0" top="30.0" />
+               </padding>
+            </HBox>
+         </children>
+      </VBox>
+   </center>
+   <top>
+      <ImageView pickOnBounds="true" preserveRatio="true" BorderPane.alignment="CENTER">
          <image>
             <Image url="@BORDE%20SUPERIOR%20-%20BALANPY.png" />
          </image>
       </ImageView>
-      <GridPane maxHeight="-Infinity" prefHeight="300.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
-            <ColumnConstraints hgrow="SOMETIMES" maxWidth="307.0" minWidth="10.0" prefWidth="297.0" />
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="296.0" minWidth="10.0" prefWidth="161.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-            <Label text="Nombre:">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-            </Label>
-            <Label text="Edad:" GridPane.rowIndex="1">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-            </Label>
-            <Label text="Teléfono:" GridPane.rowIndex="2">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-            </Label>
-            <Label text="Email:" GridPane.rowIndex="3">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-            </Label>
-            <Label text="Sexo:" GridPane.rowIndex="4">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-            </Label>
-            <Label text="Dirección" GridPane.rowIndex="5">
-               <font>
-                  <Font name="Poppins Bold" size="14.0" />
-               </font>
-            </Label>
-            <Label fx:id="nombre" text="Jorge Fulanito" GridPane.columnIndex="1">
-               <font>
-                  <Font name="Poppins" size="14.0" />
-               </font>
-            </Label>
-            <Label fx:id="edad" text="25 años" GridPane.columnIndex="1" GridPane.rowIndex="1">
-               <font>
-                  <Font name="Poppins" size="14.0" />
-               </font>
-            </Label>
-            <Label fx:id="telefono" text="+34 123 45 67 89" GridPane.columnIndex="1" GridPane.rowIndex="2">
-               <font>
-                  <Font name="Poppins" size="14.0" />
-               </font>
-            </Label>
-            <Label fx:id="email" text="jfulanito@hotmail.com" GridPane.columnIndex="1" GridPane.rowIndex="3">
-               <font>
-                  <Font name="Poppins" size="14.0" />
-               </font>
-            </Label>
-            <Label fx:id="sexo" text="Masculino" GridPane.columnIndex="1" GridPane.rowIndex="4">
-               <font>
-                  <Font name="Poppins" size="14.0" />
-               </font>
-            </Label>
-            <Label fx:id="direccion" text="Calle Falsa 123, Madrid" GridPane.columnIndex="1" GridPane.rowIndex="5">
-               <font>
-                  <Font name="Poppins" size="14.0" />
-               </font>
-            </Label>
-            <ImageView fitHeight="148.0" fitWidth="151.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2" GridPane.rowIndex="2">
-               <image>
-                  <Image url="@logo-balanpy.png" />
-               </image>
-            </ImageView>
-         </children>
-         <VBox.margin>
-            <Insets />
-         </VBox.margin>
-         <padding>
-            <Insets left="20.0" right="20.0" />
-         </padding>
-      </GridPane>
-      <VBox alignment="CENTER_LEFT" maxWidth="1.7976931348623157E308">
-         <children>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Editar  Perfil" textAlignment="CENTER">
-               <font>
-                  <Font name="Poppins Bold" size="12.0" />
-               </font>
-            </Button>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Cambio Contraseña (Próximamente)" textAlignment="CENTER" wrapText="true">
-               <font>
-                  <Font name="Poppins Bold" size="12.0" />
-               </font>
-               <VBox.margin>
-                  <Insets top="10.0" />
-               </VBox.margin>
-            </Button>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Añadir Archivo PPP" textAlignment="CENTER" wrapText="true">
-               <font>
-                  <Font name="Poppins Bold" size="12.0" />
-               </font>
-               <VBox.margin>
-                  <Insets top="10.0" />
-               </VBox.margin>
-            </Button>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Seguro" textAlignment="CENTER">
-               <font>
-                  <Font name="Poppins Bold" size="12.0" />
-               </font>
-               <VBox.margin>
-                  <Insets top="10.0" />
-               </VBox.margin>
-            </Button>
-         </children>
-         <VBox.margin>
-            <Insets />
-         </VBox.margin>
-         <padding>
-            <Insets left="20.0" right="20.0" top="20.0" />
-         </padding>
-      </VBox>
-      <HBox alignment="TOP_RIGHT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="270.0">
-         <children>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Términos de Uso y Condiciones" textAlignment="CENTER" wrapText="true">
-               <font>
-                  <Font name="Poppins Bold" size="12.0" />
-               </font>
-               <HBox.margin>
-                  <Insets right="10.0" />
-               </HBox.margin>
-            </Button>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Acerca de Nosotros" textAlignment="CENTER" wrapText="true">
-               <font>
-                  <Font name="Poppins Bold" size="12.0" />
-               </font>
-               <HBox.margin>
-                  <Insets left="5.0" right="5.0" />
-               </HBox.margin>
-            </Button>
-            <Button maxHeight="-Infinity" maxWidth="-Infinity" mnemonicParsing="false" onMouseClicked="#HandleDone" prefHeight="100.0" prefWidth="150.0" text="Manual de Uso" textAlignment="CENTER" wrapText="true">
-               <font>
-                  <Font name="Poppins Bold" size="12.0" />
-               </font>
-               <HBox.margin>
-                  <Insets left="10.0" />
-               </HBox.margin>
-            </Button>
-         </children>
-         <VBox.margin>
-            <Insets />
-         </VBox.margin>
-         <padding>
-            <Insets bottom="30.0" left="20.0" right="20.0" top="30.0" />
-         </padding>
-      </HBox>
-      <fx:include maxHeight="-Infinity" prefHeight="250.0" source="BarraTareas.fxml" />
-   </children>
-</VBox>
+   </top>
+   <bottom>
+      <fx:include maxHeight="-Infinity" source="BarraTareas.fxml" />
+   </bottom>
+</BorderPane>

--- a/src/main/resources/PortadaAplicacion.fxml
+++ b/src/main/resources/PortadaAplicacion.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
@@ -11,158 +12,166 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<VBox alignment="TOP_CENTER" prefHeight="800.0" prefWidth="600.0" style="-fx-background-color: #FFF;" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.PortadaAplicacion">
-   <children>
-      <ImageView fitHeight="100.0" fitWidth="600.0" pickOnBounds="true" preserveRatio="true">
+<BorderPane xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.PortadaAplicacion">
+   <center>
+      <VBox alignment="TOP_CENTER" style="-fx-background-color: #FFF;">
+         <children>
+            <GridPane maxHeight="1.7976931348623157E308" maxWidth="-Infinity" prefHeight="80.0" prefWidth="500.0">
+              <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" maxWidth="369.0" minWidth="10.0" prefWidth="369.0" />
+                <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="206.0" minWidth="10.0" prefWidth="131.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+              </rowConstraints>
+               <VBox.margin>
+                  <Insets />
+               </VBox.margin>
+               <children>
+                  <VBox prefHeight="200.0" prefWidth="100.0">
+                     <children>
+                        <Label text="Bienvenido a Balanpy" textFill="#83d4c8">
+                           <font>
+                              <Font name="Poppins Bold" size="30.0" />
+                           </font>
+                        </Label>
+                        <Label text="Por favor, seleccione un perfil:">
+                           <font>
+                              <Font name="Poppins Bold" size="14.0" />
+                           </font>
+                           <opaqueInsets>
+                              <Insets />
+                           </opaqueInsets>
+                        </Label>
+                     </children>
+                  </VBox>
+                  <ImageView fitHeight="150.0" fitWidth="130.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="1">
+                     <image>
+                        <Image url="@logo-balanpy.png" />
+                     </image>
+                  </ImageView>
+               </children>
+            </GridPane>
+            <GridPane maxHeight="1.7976931348623157E308" maxWidth="-Infinity" prefHeight="200.0" prefWidth="550.0">
+              <columnConstraints>
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+              </rowConstraints>
+               <VBox.margin>
+                  <Insets top="50.0" />
+               </VBox.margin>
+               <children>
+                  <VBox alignment="TOP_CENTER" onMouseClicked="#selectProfile0" styleClass="usuario" stylesheets="@usuario.css">
+                     <children>
+                        <ImageView fx:id="petImage0" fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
+                           <image>
+                              <Image url="@añadir-usuario-balanpy.png" />
+                           </image>
+                        </ImageView>
+                        <Label fx:id="petName0" text="Añadir Mascota" textAlignment="CENTER">
+                           <font>
+                              <Font name="Poppins Bold" size="16.0" />
+                           </font>
+                        </Label>
+                     </children>
+                  </VBox>
+                  <VBox alignment="TOP_CENTER" layoutX="10.0" layoutY="10.0" onMouseClicked="#selectProfile1" prefHeight="200.0" prefWidth="100.0" styleClass="usuario" stylesheets="@usuario.css" GridPane.columnIndex="1">
+                     <children>
+                        <ImageView fx:id="petImage1" fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
+                           <image>
+                              <Image url="@añadir-usuario-balanpy.png" />
+                           </image>
+                        </ImageView>
+                        <Label fx:id="petName1" text="Añadir Mascota" textAlignment="CENTER">
+                           <font>
+                              <Font name="Poppins Bold" size="16.0" />
+                           </font>
+                        </Label>
+                     </children>
+                  </VBox>
+                  <VBox alignment="TOP_CENTER" layoutX="194.0" layoutY="10.0" onMouseClicked="#selectProfile2" prefHeight="200.0" prefWidth="100.0" styleClass="usuario" stylesheets="@usuario.css" GridPane.columnIndex="2">
+                     <children>
+                        <ImageView fx:id="petImage2" fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
+                           <image>
+                              <Image url="@añadir-usuario-balanpy.png" />
+                           </image>
+                        </ImageView>
+                        <Label fx:id="petName2" text="Añadir Mascota" textAlignment="CENTER">
+                           <font>
+                              <Font name="Poppins Bold" size="16.0" />
+                           </font>
+                        </Label>
+                     </children>
+                  </VBox>
+               </children>
+            </GridPane>
+            <Label text="Acceso Rápido" textFill="#83d4c8">
+               <font>
+                  <Font name="Poppins Bold" size="30.0" />
+               </font>
+               <VBox.margin>
+                  <Insets top="20.0" />
+               </VBox.margin>
+            </Label>
+            <HBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="80.0" prefWidth="550.0">
+               <children>
+                  <VBox alignment="CENTER" onMouseClicked="#temperaturaExterna" prefHeight="100.0" prefWidth="100.0" styleClass="acceso-rapido" stylesheets="@usuario.css">
+                     <children>
+                        <Label text="Temp. Externa" textAlignment="CENTER" textFill="WHITE" wrapText="true">
+                           <font>
+                              <Font name="Poppins Bold" size="14.0" />
+                           </font>
+                        </Label>
+                     </children>
+                     <HBox.margin>
+                        <Insets right="10.0" />
+                     </HBox.margin>
+                  </VBox>
+                  <VBox alignment="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" onMouseClicked="#higiene" prefHeight="100.0" prefWidth="100.0" styleClass="acceso-rapido" stylesheets="@usuario.css">
+                     <children>
+                        <Label text="Higiene" textAlignment="CENTER" textFill="WHITE" wrapText="true">
+                           <font>
+                              <Font name="Poppins Bold" size="14.0" />
+                           </font>
+                        </Label>
+                     </children>
+                     <HBox.margin>
+                        <Insets left="5.0" right="5.0" />
+                     </HBox.margin>
+                  </VBox>
+                  <VBox alignment="CENTER" onMouseClicked="#vacunas" prefHeight="200.0" prefWidth="100.0" styleClass="acceso-rapido" stylesheets="@usuario.css">
+                     <children>
+                        <Label text="Vacunas" textAlignment="CENTER" textFill="WHITE" wrapText="true">
+                           <font>
+                              <Font name="Poppins Bold" size="14.0" />
+                           </font>
+                        </Label>
+                     </children>
+                     <HBox.margin>
+                        <Insets left="10.0" />
+                     </HBox.margin>
+                  </VBox>
+               </children>
+               <VBox.margin>
+                  <Insets top="20.0" />
+               </VBox.margin>
+            </HBox>
+            <VBox alignment="BOTTOM_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="100.0" prefWidth="600.0" />
+         </children>
+      </VBox>
+   </center>
+   <bottom>
+      <fx:include source="BarraTareas.fxml" />
+   </bottom>
+   <top>
+      <ImageView fitHeight="100.0" fitWidth="600.0" pickOnBounds="true" preserveRatio="true" BorderPane.alignment="CENTER">
          <image>
             <Image url="@BORDE%20SUPERIOR%20-%20BALANPY.png" />
          </image>
       </ImageView>
-      <GridPane maxHeight="1.7976931348623157E308" maxWidth="-Infinity" prefHeight="80.0" prefWidth="500.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="369.0" minWidth="10.0" prefWidth="369.0" />
-          <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="206.0" minWidth="10.0" prefWidth="131.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <VBox.margin>
-            <Insets />
-         </VBox.margin>
-         <children>
-            <VBox prefHeight="200.0" prefWidth="100.0">
-               <children>
-                  <Label text="Bienvenido a Balanpy" textFill="#83d4c8">
-                     <font>
-                        <Font name="Poppins Bold" size="30.0" />
-                     </font>
-                  </Label>
-                  <Label text="Por favor, seleccione un perfil:">
-                     <font>
-                        <Font name="Poppins Bold" size="14.0" />
-                     </font>
-                     <opaqueInsets>
-                        <Insets />
-                     </opaqueInsets>
-                  </Label>
-               </children>
-            </VBox>
-            <ImageView fitHeight="150.0" fitWidth="130.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="1">
-               <image>
-                  <Image url="@logo-balanpy.png" />
-               </image>
-            </ImageView>
-         </children>
-      </GridPane>
-      <GridPane maxHeight="1.7976931348623157E308" maxWidth="-Infinity" prefHeight="200.0" prefWidth="550.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <VBox.margin>
-            <Insets top="50.0" />
-         </VBox.margin>
-         <children>
-            <VBox alignment="TOP_CENTER" onMouseClicked="#selectProfile0" styleClass="usuario" stylesheets="@usuario.css">
-               <children>
-                  <ImageView fx:id="petImage0" fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
-                     <image>
-                        <Image url="@añadir-usuario-balanpy.png" />
-                     </image>
-                  </ImageView>
-                  <Label fx:id="petName0" text="Añadir Mascota" textAlignment="CENTER">
-                     <font>
-                        <Font name="Poppins Bold" size="16.0" />
-                     </font>
-                  </Label>
-               </children>
-            </VBox>
-            <VBox alignment="TOP_CENTER" layoutX="10.0" layoutY="10.0" onMouseClicked="#selectProfile1" prefHeight="200.0" prefWidth="100.0" styleClass="usuario" stylesheets="@usuario.css" GridPane.columnIndex="1">
-               <children>
-                  <ImageView fx:id="petImage1" fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
-                     <image>
-                        <Image url="@añadir-usuario-balanpy.png" />
-                     </image>
-                  </ImageView>
-                  <Label fx:id="petName1" text="Añadir Mascota" textAlignment="CENTER">
-                     <font>
-                        <Font name="Poppins Bold" size="16.0" />
-                     </font>
-                  </Label>
-               </children>
-            </VBox>
-            <VBox alignment="TOP_CENTER" layoutX="194.0" layoutY="10.0" onMouseClicked="#selectProfile2" prefHeight="200.0" prefWidth="100.0" styleClass="usuario" stylesheets="@usuario.css" GridPane.columnIndex="2">
-               <children>
-                  <ImageView fx:id="petImage2" fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
-                     <image>
-                        <Image url="@añadir-usuario-balanpy.png" />
-                     </image>
-                  </ImageView>
-                  <Label fx:id="petName2" text="Añadir Mascota" textAlignment="CENTER">
-                     <font>
-                        <Font name="Poppins Bold" size="16.0" />
-                     </font>
-                  </Label>
-               </children>
-            </VBox>
-         </children>
-      </GridPane>
-      <Label text="Acceso Rápido" textFill="#83d4c8">
-         <font>
-            <Font name="Poppins Bold" size="30.0" />
-         </font>
-         <VBox.margin>
-            <Insets top="20.0" />
-         </VBox.margin>
-      </Label>
-      <HBox alignment="TOP_CENTER" maxHeight="-Infinity" maxWidth="-Infinity" prefHeight="80.0" prefWidth="550.0">
-         <children>
-            <VBox alignment="CENTER" onMouseClicked="#temperaturaExterna" prefHeight="100.0" prefWidth="100.0" styleClass="acceso-rapido" stylesheets="@usuario.css">
-               <children>
-                  <Label text="Temp. Externa" textAlignment="CENTER" textFill="WHITE" wrapText="true">
-                     <font>
-                        <Font name="Poppins Bold" size="14.0" />
-                     </font>
-                  </Label>
-               </children>
-               <HBox.margin>
-                  <Insets right="10.0" />
-               </HBox.margin>
-            </VBox>
-            <VBox alignment="CENTER" maxHeight="-Infinity" maxWidth="-Infinity" onMouseClicked="#higiene" prefHeight="100.0" prefWidth="100.0" styleClass="acceso-rapido" stylesheets="@usuario.css">
-               <children>
-                  <Label text="Higiene" textAlignment="CENTER" textFill="WHITE" wrapText="true">
-                     <font>
-                        <Font name="Poppins Bold" size="14.0" />
-                     </font>
-                  </Label>
-               </children>
-               <HBox.margin>
-                  <Insets left="5.0" right="5.0" />
-               </HBox.margin>
-            </VBox>
-            <VBox alignment="CENTER" onMouseClicked="#vacunas" prefHeight="200.0" prefWidth="100.0" styleClass="acceso-rapido" stylesheets="@usuario.css">
-               <children>
-                  <Label text="Vacunas" textAlignment="CENTER" textFill="WHITE" wrapText="true">
-                     <font>
-                        <Font name="Poppins Bold" size="14.0" />
-                     </font>
-                  </Label>
-               </children>
-               <HBox.margin>
-                  <Insets left="10.0" />
-               </HBox.margin>
-            </VBox>
-         </children>
-         <VBox.margin>
-            <Insets top="20.0" />
-         </VBox.margin>
-      </HBox>
-      <VBox alignment="BOTTOM_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="100.0" prefWidth="600.0" />
-      <fx:include source="BarraTareas.fxml" />
-   </children>
-</VBox>
+   </top>
+</BorderPane>

--- a/src/main/resources/Pulsaciones.fxml
+++ b/src/main/resources/Pulsaciones.fxml
@@ -6,91 +6,98 @@
 <?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Circle?>
 <?import javafx.scene.shape.Rectangle?>
 <?import javafx.scene.text.Font?>
 
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.Pulsaciones">
-   <children>
-      <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#87d5ca" height="146.0" stroke="BLACK" strokeType="INSIDE" width="129.0">
-         <VBox.margin>
-            <Insets left="70.0" top="30.0" />
-         </VBox.margin>
-      </Rectangle>
-      <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#87d5ca" height="146.0" stroke="BLACK" strokeType="INSIDE" width="129.0">
-         <VBox.margin>
-            <Insets left="248.0" top="-145.0" />
-         </VBox.margin>
-      </Rectangle>
-      <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#87d5ca" height="146.0" stroke="BLACK" strokeType="INSIDE" width="129.0">
-         <VBox.margin>
-            <Insets left="420.0" top="-145.0" />
-         </VBox.margin>
-      </Rectangle>
-      <Label text="Sansa">
-         <VBox.margin>
-            <Insets left="110.0" top="-30.0" />
-         </VBox.margin>
-         <font>
-            <Font name="Arial Black" size="14.0" />
-         </font>
-      </Label>
-      <Circle fill="WHITE" radius="45.0" stroke="BLACK" strokeType="INSIDE">
-         <VBox.margin>
-            <Insets left="90.0" top="-120.0" />
-         </VBox.margin>
-      </Circle>
-      <Label text="Hank">
-         <font>
-            <Font name="Arial Black" size="14.0" />
-         </font>
-         <VBox.margin>
-            <Insets left="295.0" top="10.0" />
-         </VBox.margin>
-      </Label>
-      <Circle fill="WHITE" radius="45.0" stroke="BLACK" strokeType="INSIDE">
-         <VBox.margin>
-            <Insets left="270.0" top="-120.0" />
-         </VBox.margin>
-      </Circle>
-      <Label text="98">
-         <font>
-            <Font name="Arial Black" size="36.0" />
-         </font>
-         <VBox.margin>
-            <Insets left="110.0" top="-70.0" />
-         </VBox.margin>
-      </Label>
-      <Label text="87">
-         <font>
-            <Font name="Arial Black" size="36.0" />
-         </font>
-         <VBox.margin>
-            <Insets left="290.0" top="-55.0" />
-         </VBox.margin>
-      </Label>
-      <LineChart prefHeight="200.0" prefWidth="100.0">
-        <xAxis>
-          <CategoryAxis side="BOTTOM" />
-        </xAxis>
-        <yAxis>
-          <NumberAxis side="LEFT" />
-        </yAxis>
-         <VBox.margin>
-            <Insets left="80.0" right="80.0" top="100.0" />
-         </VBox.margin>
-      </LineChart>
-      <Button mnemonicParsing="false" onMouseClicked="#HandleDone" text="Descarga documento PDF">
-         <font>
-            <Font name="Arial Black" size="18.0" />
-         </font>
-         <VBox.margin>
-            <Insets left="150.0" top="100.0" />
-         </VBox.margin>
-      </Button>
-      <VBox alignment="BOTTOM_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="100.0" prefWidth="600.0" />
+<BorderPane xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.balanpy.Pulsaciones">
+   <center>
+      <VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity">
+         <children>
+            <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#87d5ca" height="146.0" stroke="BLACK" strokeType="INSIDE" width="129.0">
+               <VBox.margin>
+                  <Insets left="70.0" top="30.0" />
+               </VBox.margin>
+            </Rectangle>
+            <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#87d5ca" height="146.0" stroke="BLACK" strokeType="INSIDE" width="129.0">
+               <VBox.margin>
+                  <Insets left="248.0" top="-145.0" />
+               </VBox.margin>
+            </Rectangle>
+            <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#87d5ca" height="146.0" stroke="BLACK" strokeType="INSIDE" width="129.0">
+               <VBox.margin>
+                  <Insets left="420.0" top="-145.0" />
+               </VBox.margin>
+            </Rectangle>
+            <Label text="Sansa">
+               <VBox.margin>
+                  <Insets left="110.0" top="-30.0" />
+               </VBox.margin>
+               <font>
+                  <Font name="Arial Black" size="14.0" />
+               </font>
+            </Label>
+            <Circle fill="WHITE" radius="45.0" stroke="BLACK" strokeType="INSIDE">
+               <VBox.margin>
+                  <Insets left="90.0" top="-120.0" />
+               </VBox.margin>
+            </Circle>
+            <Label text="Hank">
+               <font>
+                  <Font name="Arial Black" size="14.0" />
+               </font>
+               <VBox.margin>
+                  <Insets left="295.0" top="10.0" />
+               </VBox.margin>
+            </Label>
+            <Circle fill="WHITE" radius="45.0" stroke="BLACK" strokeType="INSIDE">
+               <VBox.margin>
+                  <Insets left="270.0" top="-120.0" />
+               </VBox.margin>
+            </Circle>
+            <Label text="98">
+               <font>
+                  <Font name="Arial Black" size="36.0" />
+               </font>
+               <VBox.margin>
+                  <Insets left="110.0" top="-70.0" />
+               </VBox.margin>
+            </Label>
+            <Label text="87">
+               <font>
+                  <Font name="Arial Black" size="36.0" />
+               </font>
+               <VBox.margin>
+                  <Insets left="290.0" top="-55.0" />
+               </VBox.margin>
+            </Label>
+            <LineChart prefHeight="200.0" prefWidth="100.0">
+              <xAxis>
+                <CategoryAxis side="BOTTOM" />
+              </xAxis>
+              <yAxis>
+                <NumberAxis side="LEFT" />
+              </yAxis>
+               <VBox.margin>
+                  <Insets left="80.0" right="80.0" top="100.0" />
+               </VBox.margin>
+            </LineChart>
+            <Button mnemonicParsing="false" onMouseClicked="#HandleDone" text="Descarga documento PDF">
+               <font>
+                  <Font name="Arial Black" size="18.0" />
+               </font>
+               <VBox.margin>
+                  <Insets left="150.0" top="100.0" />
+               </VBox.margin>
+            </Button>
+            <VBox alignment="BOTTOM_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="100.0" prefWidth="600.0" />
+         </children>
+      </VBox>
+   </center>
+   <bottom>
       <fx:include source="BarraTareas.fxml" />
-   </children>
-</VBox>
+   </bottom>
+</BorderPane>


### PR DESCRIPTION
Se utilizan `BorderPane`s donde fuese posible para obligar a la barra de tareas a pegarse al fondo de las pantallas. También se utiliza la parte superior para ubicar algunas imagenes.